### PR TITLE
chore: Replace play-json JSON parsing with circe

### DIFF
--- a/sinister-service/app/models/Card.scala
+++ b/sinister-service/app/models/Card.scala
@@ -1,17 +1,26 @@
 package models
 
-import play.api.libs.json.{Json, Writes}
+import io.circe.{Decoder, Encoder, Json}
+import io.circe.generic.semiauto.deriveDecoder
 
 case class Card(ordinal: Int) {
-  def readable: String = {
-    val rank = Card.Ranks(ordinal / 4)
-    val suit = Card.Suits(ordinal % 4)
+  val faceDown: Boolean = ordinal == -1
 
-    s"$rank$suit"
+  def readable: String = {
+    if (ordinal < 0) {
+      "Xx"
+    } else {
+      val rank = Card.Ranks(ordinal / 4)
+      val suit = Card.Suits(ordinal % 4)
+
+      s"$rank$suit"
+    }
   }
 }
 
 object Card {
+  implicit val decoder: Decoder[Card] = deriveDecoder
+
   def deserialize(cardData: String): Seq[Card] = {
     if (cardData != "-1;-1") {
       cardData.split(";")
@@ -27,9 +36,6 @@ object Card {
 
   val Suits = List("c", "d", "h", "s")
   val Ranks = List("2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K", "A")
-  implicit val writes: Writes[Card] = (card: Card) => {
-    Json.obj(
-      "value" -> card.readable
-    )
-  }
+
+  implicit val encoder: Encoder[Card] = (a: Card) => Json.fromString(a.readable)
 }

--- a/sinister-service/app/models/Dealer.scala
+++ b/sinister-service/app/models/Dealer.scala
@@ -1,7 +1,7 @@
 package models
 
-import play.api.libs.functional.syntax.toFunctionalBuilderOps
-import play.api.libs.json._
+import io.circe.generic.semiauto.deriveEncoder
+import io.circe.{Decoder, Encoder, HCursor}
 
 case class Dealer(
     cards: Seq[Card]
@@ -16,5 +16,12 @@ case class Dealer(
 }
 
 object Dealer {
-  implicit val reads: Reads[Dealer] = (JsPath \ "c").read[String].map(Card.deserialize).map(Dealer.apply)
+  implicit val decoder: Decoder[Dealer] = (c: HCursor) =>
+    for {
+      rawCards <- c.downField("c").as[String]
+    } yield {
+      Dealer(Card.deserialize(rawCards))
+    }
+
+  implicit val encoder: Encoder[Dealer] = deriveEncoder
 }

--- a/sinister-service/app/models/GameState.scala
+++ b/sinister-service/app/models/GameState.scala
@@ -1,27 +1,26 @@
 package models
 
-import play.api.libs.functional.syntax.toFunctionalBuilderOps
-import play.api.libs.json.{JsPath, Reads}
-
+import io.circe._
+import io.circe.generic.semiauto._
 
 case class GameState(
-                      tableId: Int,
-                      gameId: Int,
-                      seatedPlayers: Seq[SeatedPlayer],
-                      smallBlindIndex: Int,
-                      bigBlindIndex: Int,
-                      dealer: Dealer
-                    ) {}
+    tableId: Int,
+    gameId: Int,
+    seatedPlayers: Seq[Option[SeatedPlayer]],
+    smallBlindIndex: Int,
+    bigBlindIndex: Int,
+    dealer: Dealer
+) {}
 object GameState {
 
+  implicit val decoder: Decoder[GameState] = Decoder.forProduct6(
+    "ti",
+    "gi",
+    "s",
+    "sb",
+    "bb",
+    "d"
+  )(GameState.apply)
 
-  implicit val readsBuilder: Reads[GameState] = (
-    (JsPath \ "ti").read[Int] and
-      (JsPath \ "gi").read[Int] and
-      (JsPath \ "s").read[Seq[SeatedPlayer]] and
-      (JsPath \ "sb").read[Int] and
-      (JsPath \ "bb").read[Int] and
-      (JsPath \ "d").read[Dealer]
-    )(GameState.apply _)
-  //    implicit val format: Format[GameState] = Json.format[GameState]
+  implicit val encoder: Encoder[GameState] = deriveEncoder
 }

--- a/sinister-service/app/models/GameStateEvent.scala
+++ b/sinister-service/app/models/GameStateEvent.scala
@@ -1,9 +1,252 @@
 package models
 
-import play.api.libs.json.{Json, Reads}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder, HCursor, Json}
 
-case class GameStateEvent(`type`: Int)
+trait GameStateEvent {
+  def encoded: Json
+}
+
+case class UnknownEvent(`type`: Int, raw: Json) extends GameStateEvent {
+  def encoded: Json = UnknownEvent.encoded(this)
+}
+object UnknownEvent {
+  implicit val encoded: Encoder[UnknownEvent] = deriveEncoder
+}
+
+case class TransferActionEvent(actionToSeat: Int) extends GameStateEvent {
+  override def encoded: Json = TransferActionEvent.encoder(this)
+}
+object TransferActionEvent {
+  implicit val encoder: Encoder[TransferActionEvent] = deriveEncoder
+
+  implicit val decoder: Decoder[TransferActionEvent] =
+    (c: HCursor) => {
+      for {
+        actionTarget <- c.downField("seat-idx").as[Int]
+      } yield TransferActionEvent(actionTarget)
+    }
+}
+
+case class PlayerAction(subAction: Int, rawJson: Json) extends GameStateEvent {
+  val encoded: Json = {
+    Json.obj(
+      "undefinedPlayerAction" -> Json.fromBoolean(true),
+      "subAction" -> Json.fromInt(subAction),
+      "source" -> rawJson
+    )
+  }
+}
+
+object PlayerAction {
+
+  private val FOLD = Some(1)
+  private val CHECK = Some(2)
+  private val CALL = Some(3)
+  private val SMALL_BLIND = Some(6)
+  private val BIG_BLIND = Some(7)
+  private val BET = Some(8)
+  private val RAISE = Some(9)
+  private val SHOW_CARDS = Some(10)
+  private val DO_NOT_SHOW_CARDS = Some(16)
+
+  def interpret(rawJson: Json): GameStateEvent = {
+
+    rawJson.asObject
+      .map(jso => {
+
+        val actionType = jso("action").flatMap(_.asNumber.flatMap(_.toInt))
+        val extractedSeatIndex =
+          jso("seat-idx").flatMap(_.asNumber.flatMap(_.toInt))
+        val extractedAmount = jso("amount").flatMap(_.asNumber.flatMap(_.toInt))
+
+        val playerAction =
+          (actionType, extractedSeatIndex, extractedAmount) match {
+
+            case (None, _, _) => ???
+            case (FOLD, Some(seatIndex), _) =>
+              PlayerFold(seatIndex)
+            case (CHECK, Some(seatIndex), _) =>
+              PlayerCheck(seatIndex)
+            case (CALL, Some(seatIndex), Some(amount)) =>
+              PlayerActionCall(seatIndex, amount)
+            case (SMALL_BLIND, Some(seatIndex), Some(amount)) =>
+              SmallBlind(seatIndex, amount)
+            case (BIG_BLIND, Some(seatIndex), Some(amount)) =>
+              BigBlind(seatIndex, amount)
+            case (BET, Some(seatIndex), Some(amount)) =>
+              Bet(seatIndex, amount)
+            case (RAISE, Some(seatIndex), Some(amount)) =>
+              Raise(seatIndex, amount)
+            case (SHOW_CARDS, Some(seatIndex), _) =>
+              ShowCards(seatIndex)
+            case (DO_NOT_SHOW_CARDS, Some(seatIndex), _) =>
+              DoNotShowCards(seatIndex)
+            case (Some(actionType), _, _) => PlayerAction(actionType, rawJson)
+          }
+
+        playerAction
+      })
+      .getOrElse(PlayerAction(-89, rawJson))
+  }
+}
+
+case class SmallBlind(seatIndex: Int, amount: Int) extends GameStateEvent {
+  def encoded: Json = {
+    Json.obj(
+      "smallBlind" -> Json.fromInt(amount),
+      "player" -> Json.fromInt(seatIndex)
+    )
+  }
+}
+
+case class BigBlind(seatIndex: Int, amount: Int) extends GameStateEvent {
+  def encoded: Json = {
+    Json.obj(
+      "bigBlind" -> Json.fromInt(amount),
+      "player" -> Json.fromInt(seatIndex)
+    )
+  }
+}
+
+case class Bet(seatIndex: Int, amount: Int) extends GameStateEvent {
+  def encoded: Json = {
+    Json.obj(
+      "bet" -> Json.fromInt(amount),
+      "player" -> Json.fromInt(seatIndex)
+    )
+  }
+}
+
+case class Raise(seatIndex: Int, amount: Int) extends GameStateEvent {
+  def encoded: Json = {
+    Json.obj(
+      "raise" -> Json.fromInt(amount),
+      "player" -> Json.fromInt(seatIndex)
+    )
+  }
+}
+
+case class PlayerActionCall(seatIndex: Int, amount: Int)
+    extends GameStateEvent {
+  def encoded: Json = {
+    Json.obj(
+      "call" -> Json.fromInt(amount),
+      "player" -> Json.fromInt(seatIndex)
+    )
+  }
+}
+
+case class PlayerFold(seatIndex: Int) extends GameStateEvent {
+  def encoded: Json = {
+    Json.obj("playerFold" -> Json.fromInt(seatIndex))
+  }
+}
+
+case class PlayerCheck(seatIndex: Int) extends GameStateEvent {
+  def encoded: Json = {
+    Json.obj("playerCheck" -> Json.fromInt(seatIndex))
+  }
+}
+
+case class DealPlayerCard(seatIndex: Int) extends GameStateEvent {
+  override def encoded: Json =
+    Json.obj(
+      "dealCard" -> Json.fromInt(seatIndex)
+    )
+}
+
+case class ShowHand(seatIndex: Int) extends GameStateEvent {
+  override def encoded: Json =
+    Json.obj(
+      "showHand" -> Json.fromInt(seatIndex)
+    )
+}
+
+case class ShowCards(seatIndex: Int) extends GameStateEvent {
+  override def encoded: Json =
+    Json.obj(
+      "showCards" -> Json.fromInt(seatIndex)
+    )
+}
+
+case class DoNotShowCards(seatIndex: Int) extends GameStateEvent {
+
+  override def encoded: Json =
+    Json.obj(
+      "doNotShowCards" -> Json.fromInt(seatIndex)
+    )
+}
+
+case class SubtractChips(seatIndex: Int, amount: Int) extends GameStateEvent {
+  override def encoded: Json =
+    Json.obj(
+      "subtractChips" -> Json.fromInt(amount),
+      "player" -> Json.fromInt(seatIndex)
+    )
+
+}
+
+case class DealerRake(amount: Int) extends GameStateEvent {
+  override def encoded: Json =
+    Json.obj(
+      "rake" -> Json.fromInt(amount)
+    )
+
+  implicit val decoder: Decoder[DealerRake] = deriveDecoder
+}
+
+case class DealCommunityCard(seatIndex: Int) extends GameStateEvent {
+  override def encoded: Json =
+    Json.obj(
+      "dealCommunityCard" -> Json.fromBoolean(true)
+    )
+}
+
+case object EnterNextPhase extends GameStateEvent {
+  def apply(): Any = ???
+
+  override def encoded: Json = {
+    Json.obj("nextPhase" -> Json.fromBoolean(true))
+  }
+}
 
 object GameStateEvent {
-  implicit val reads: Reads[GameStateEvent] = Json.reads[GameStateEvent]
+  implicit val decoder: Decoder[GameStateEvent] = (c: HCursor) => {
+    for {
+      eventType <- c.downField("type").as[Int]
+    } yield interpret(eventType, c.value)
+  }
+
+  def interpret(eventType: Int, rawJson: Json): GameStateEvent = {
+    rawJson.asObject
+      .map[GameStateEvent] { jso =>
+        val seatIndex = (rawJson \\ "seat-idx").head.as[Int].getOrElse(-227)
+        eventType match {
+          case 1 => DealPlayerCard(seatIndex)
+          case 2 => DealCommunityCard(seatIndex)
+          case 3 => EnterNextPhase
+          case 4 =>
+            val chipAmount = jso("amount").flatMap(_.asNumber.flatMap(_.toInt))
+            SubtractChips(seatIndex, chipAmount.getOrElse(0))
+          case 6 =>
+            TransferActionEvent.decoder
+              .decodeJson(rawJson)
+              .getOrElse(UnknownEvent(-6, rawJson))
+          case 8 =>
+            deriveDecoder[DealerRake]
+              .decodeJson(rawJson)
+              .getOrElse(DealerRake(-1))
+          case 9       => PlayerAction.interpret(rawJson)
+          case 25      => ShowHand(seatIndex)
+          case default => UnknownEvent(eventType, rawJson)
+        }
+      }
+      .getOrElse(UnknownEvent(0, rawJson))
+  }
+
+  implicit val encoder: Encoder[GameStateEvent] =
+    (gameStateEvent: GameStateEvent) => {
+      gameStateEvent.encoded
+    }
 }

--- a/sinister-service/app/models/GameStateMessage.scala
+++ b/sinister-service/app/models/GameStateMessage.scala
@@ -1,6 +1,7 @@
 package models
 
-import play.api.libs.json.{Json, Reads}
+import io.circe._
+import io.circe.generic.semiauto._
 
 case class GameStateMessage(
     id: Int,
@@ -8,5 +9,5 @@ case class GameStateMessage(
     events: Seq[GameStateEvent]
 )
 object GameStateMessage {
-  implicit val reads: Reads[GameStateMessage] = Json.reads[GameStateMessage]
+  implicit val decoder: Decoder[GameStateMessage] = deriveDecoder
 }

--- a/sinister-service/app/models/Hand.scala
+++ b/sinister-service/app/models/Hand.scala
@@ -1,0 +1,10 @@
+package models
+
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
+
+case class Hand(summary: HandSummary, events: Seq[GameStateEvent]) {}
+
+object Hand {
+  implicit val encoder: Encoder[Hand] = deriveEncoder
+}

--- a/sinister-service/build.sbt
+++ b/sinister-service/build.sbt
@@ -10,6 +10,16 @@ scalaVersion := "2.13.4"
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
 
+val circeVersion = "0.12.3"
+
+libraryDependencies ++= Seq(
+  "io.circe" %% "circe-core",
+  "io.circe" %% "circe-generic",
+  "io.circe" %% "circe-parser"
+).map(_ % circeVersion)
+
+libraryDependencies += "io.circe" %% "circe-generic-extras" % "0.13.0"
+libraryDependencies += "com.dripower" %% "play-circe" % "2812.0"
 // Adds additional packages into Twirl
 //TwirlKeys.templateImports += "com.semisafe.controllers._"
 

--- a/sinister-service/test/controllers/HomeControllerSpec.scala
+++ b/sinister-service/test/controllers/HomeControllerSpec.scala
@@ -7,12 +7,15 @@ import play.api.test._
 import play.api.test.Helpers._
 
 /**
- * Add your spec here.
- * You can mock out a whole application including requests, plugins etc.
- *
- * For more information, see https://www.playframework.com/documentation/latest/ScalaTestingWithScalaTest
- */
-class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting {
+  * Add your spec here.
+  * You can mock out a whole application including requests, plugins etc.
+  *
+  * For more information, see https://www.playframework.com/documentation/latest/ScalaTestingWithScalaTest
+  */
+class HomeControllerSpec
+    extends PlaySpec
+    with GuiceOneAppPerTest
+    with Injecting {
 
   "HomeController GET" should {
 
@@ -22,7 +25,7 @@ class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
-      contentAsString(home) must include ("Welcome to Play")
+      contentAsString(home) must include("Welcome to Play")
     }
 
     "render the index page from the application" in {
@@ -31,7 +34,7 @@ class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
-      contentAsString(home) must include ("Welcome to Play")
+      contentAsString(home) must include("Welcome to Play")
     }
 
     "render the index page from the router" in {
@@ -40,7 +43,21 @@ class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
-      contentAsString(home) must include ("Welcome to Play")
+      contentAsString(home) must include("Welcome to Play")
+    }
+
+    val logger = play.api.Logger("application")
+    "parse the hands" in {
+      val controller = inject[HomeController]
+      val home = controller
+        .parseLogCache()
+        .apply(FakeRequest(GET, "/"))
+
+      status(home) mustBe OK
+
+      val result = contentAsJson(home)
+      logger.info(s"Result: $result")
+
     }
   }
 }

--- a/sinister-service/test/models/CardSpec.scala
+++ b/sinister-service/test/models/CardSpec.scala
@@ -1,8 +1,8 @@
 package models
 
+import io.circe.Json
 import org.scalatest.matchers._
 import org.scalatest.wordspec.AnyWordSpecLike
-import play.api.libs.json.Json
 
 class CardSpec extends AnyWordSpecLike with must.Matchers {
   "Card" must {
@@ -17,11 +17,9 @@ class CardSpec extends AnyWordSpecLike with must.Matchers {
     "serialize to JSON as expected" in {
       val card = Card(48)
 
-      val asJson = Json.toJson(card)
+      val asJson = Card.encoder(card)
 
-      val expected = Json.obj(
-        "value" -> "Ac"
-      )
+      val expected = Json.fromString("Ac")
 
       asJson mustBe expected
     }

--- a/sinister-service/test/models/DealerSpec.scala
+++ b/sinister-service/test/models/DealerSpec.scala
@@ -1,8 +1,8 @@
 package models
 
+import io.circe.parser
 import org.scalatest.matchers._
 import org.scalatest.wordspec.AnyWordSpecLike
-import play.api.libs.json.Json
 
 class DealerSpec extends AnyWordSpecLike with must.Matchers {
   "Dealer" must {
@@ -31,9 +31,11 @@ class DealerSpec extends AnyWordSpecLike with must.Matchers {
           |}
           |""".stripMargin
 
-      val parsed = Json.parse(raw).validate[Dealer]
-
-      parsed.get.cards.map(_.readable) mustBe List("4c", "Qh")
+      parser
+        .decode[Dealer](raw)
+        .map { parsed =>
+          parsed.cards.map(_.readable) mustBe List("4c", "Qh")
+        }
     }
   }
 }

--- a/sinister-service/test/scaffolding/package.scala
+++ b/sinister-service/test/scaffolding/package.scala
@@ -1,0 +1,10 @@
+import org.scalatest.enablers.{Definition, Emptiness}
+
+package object scaffolding {
+  // Stronger option implicits for scalatest
+  implicit def emptinessOfOption[e]: Emptiness[Option[e]] =
+    (opt: Option[e]) => opt.isEmpty
+
+  implicit def definitionOfOption[e]: Definition[Option[e]] =
+    (opt: Option[e]) => opt.isDefined
+}


### PR DESCRIPTION
Ran into some issues where play-json had issues with lists containing `null` values, which is expected for empty seats.