### PR TITLE
feat: Save hand results into folders for each player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ WorkspaceSettings.xcsettings
 build
 browser/node_modules
 client-mirror
+sample_data

--- a/sinister-service/.gitignore
+++ b/sinister-service/.gitignore
@@ -10,3 +10,4 @@ target
 /.g8
 /.idea/libraries
 /.idea/modules/*.iml
+player_data

--- a/sinister-service/app/controllers/HomeController.scala
+++ b/sinister-service/app/controllers/HomeController.scala
@@ -10,8 +10,10 @@ import play.api.libs.circe._
 import play.api.mvc._
 
 import java.io.{BufferedWriter, File, FileInputStream, FileWriter}
+import java.nio.file.{Files, Paths}
 import javax.inject._
 import scala.io.Source
+import scala.util.hashing.MurmurHash3
 
 /**
   * This controller creates an `Action` to handle HTTP requests to the
@@ -23,6 +25,8 @@ class HomeController @Inject() (val controllerComponents: ControllerComponents)
     with Circe {
 
   val logger: Logger = Logger("application")
+
+  val playerData = "player_data"
 
   /**
     * Create an Action to render an HTML page.
@@ -71,10 +75,31 @@ class HomeController @Inject() (val controllerComponents: ControllerComponents)
     bw.close()
   }
 
+  case class Participant(
+      name: String,
+      handsPlayed: Int
+  ) {
+    val hash = {
+      val fwHash = MurmurHash3.stringHash(name)
+      val bwHash = MurmurHash3.stringHash(name.reverse)
+
+      f"$fwHash%08x$bwHash%08x"
+    }
+  }
+  object Participant {
+    implicit val encoder: Encoder[Participant] = (participant) => {
+      Json.obj(
+        "name" -> Json.fromString(participant.name),
+        "handsPlayed" -> Json.fromInt(participant.handsPlayed),
+        "hash" -> Json.fromString(participant.hash)
+      )
+    }
+  }
+
   case class Result(
       hands: Seq[Hand],
       gameCount: Int,
-      players: Seq[(String, Int)]
+      players: Seq[Participant]
   )
   object Result {
     implicit val encoder: Encoder[Result] = deriveEncoder
@@ -91,30 +116,72 @@ class HomeController @Inject() (val controllerComponents: ControllerComponents)
       List[File]()
     }
   }
+  case class MessageWithSource(gameStateMessage: GameStateMessage, source: File)
+  implicit def extractMessage(m: MessageWithSource): GameStateMessage = {
+    m.gameStateMessage
+  }
+
+  def readCachedFiles(cachedFiles: Seq[File]) = {
+    cachedFiles.flatMap { rawHandFile =>
+      {
+        logger.info(s"Opening: $rawHandFile")
+        val source = new FileInputStream(rawHandFile)
+        val jsonContent = Source.fromInputStream(source).mkString
+        val circeParsed = parser.decode[GameStateMessage](jsonContent)
+
+        circeParsed match {
+          case Left(value) =>
+            logger.warn(s"parsing error: $value")
+            None
+          case Right(value) =>
+            Option(
+              MessageWithSource(value, rawHandFile)
+            )
+        }
+      }
+    }
+  }
+
+  def ensurePlayerDirectoryExists(player: Participant): Unit = {
+    val playerHash = player.hash
+    val playerDataDir = s"player_data/$playerHash"
+
+    val f = new File(playerDataDir)
+    if (!f.exists()) {
+      Files.createDirectories(f.toPath)
+    }
+  }
+
+  def saveSerializedHand(hand: Hand, player: Participant): Unit = {
+    val serializedHand = Hand.encoder(hand).toString()
+    val handId = hand.summary.handId
+    val filename = s"$playerData/${player.hash}/$handId.json"
+    val file = new File(filename)
+    val bw = new BufferedWriter(new FileWriter(file))
+    bw.write(serializedHand)
+    bw.close()
+}
+
+  def syndicateCompletedHands(hands: Seq[Hand]): Unit = {
+    hands
+      .filter { hand => hand.summary.isComplete }
+      .foreach { hand => {
+        hand.summary.playersDealtIn.map { player =>
+          val participant = Participant(player, 1)
+          ensurePlayerDirectoryExists(participant)
+          saveSerializedHand(hand, participant)
+        }}
+      }
+  }
 
   def parseLogCache(): Action[AnyContent] =
     Action { implicit request: Request[AnyContent] =>
       val cachedFiles = enumerateCache()
 
-      val parseCacheFiles: Seq[GameStateMessage] = cachedFiles
-        .flatMap { rawHandFile =>
-          {
-            logger.info(s"Opening: $rawHandFile")
-            val source = new FileInputStream(rawHandFile)
-            val jsonContent = Source.fromInputStream(source).mkString
-            val circeParsed = parser.decode[GameStateMessage](jsonContent)
-
-            circeParsed match {
-              case Left(value) =>
-                logger.warn(s"parsing error: $value")
-                None
-              case Right(value) => Option(value)
-            }
-          }
-        }
+      val parseCacheFiles = readCachedFiles(cachedFiles)
 
       val byGameId = parseCacheFiles
-        .groupBy(_.gameState.gameId)
+        .groupBy(_.gameStateMessage.gameState.gameId)
         .map {
           case (x, y) => x -> y.sortBy(_.id)
         }
@@ -126,6 +193,8 @@ class HomeController @Inject() (val controllerComponents: ControllerComponents)
               .sortBy(_.id)
               .map(_.gameState)
 
+            val sources = messages.map(_.source.getName)
+
             val events = messages
               .flatMap(_.events)
 
@@ -134,16 +203,14 @@ class HomeController @Inject() (val controllerComponents: ControllerComponents)
 
             val filteredEvents = events.filter(_.isInstanceOf[GameNarrative])
 
-            if (gameId == 75578234) {
-              logger.info(s"filtered: $filteredEvents")
-
-            }
-            Hand(handSummary, filteredEvents)
+            Hand(
+              handSummary,
+              filteredEvents,
+              sources
+            )
         }
         .toSeq
         .sortBy(_.summary.handId)
-
-//      logger.info(s"Hand Details: $handDetails")
 
       val gameIds = parseCacheFiles
         .map(gameStateMessage => {
@@ -151,12 +218,18 @@ class HomeController @Inject() (val controllerComponents: ControllerComponents)
         })
         .distinct
 
-      val participants = handDetails.flatMap { hand =>
-        hand.summary.playersDealtIn
-      }
+      val participants = handDetails
+        .flatMap { hand =>
+          hand.summary.playersDealtIn
+        }
         .groupBy(a => a)
-        .map(s => (s._1, s._2.size))
+        .map {
+          case (a, b) =>
+            Participant(a, b.size)
+        }
         .toSeq
+
+      syndicateCompletedHands(handDetails)
 
       val transformedResult = Result(handDetails, gameIds.length, participants)
 

--- a/sinister-service/app/models/Hand.scala
+++ b/sinister-service/app/models/Hand.scala
@@ -4,7 +4,7 @@ import io.circe.Encoder
 import io.circe.generic.semiauto.deriveEncoder
 import models.gamestate.GameStateEvent
 
-case class Hand(summary: HandSummary, events: Seq[GameStateEvent]) {}
+case class Hand(summary: HandSummary, events: Seq[GameStateEvent], sources: Seq[String]) {}
 
 object Hand {
   implicit val encoder: Encoder[Hand] = deriveEncoder


### PR DESCRIPTION
This is a fairly naive implementation that is fairly large, but will handle
faster lookup for players in isolation.

This saves the play data in murmur3 hash directories based on the player name
to remove any issues with oddly formatted player names.