### PR TITLE
fix: The state files could result in ms level collisions

### DIFF
--- a/sinister-service/app/controllers/HomeController.scala
+++ b/sinister-service/app/controllers/HomeController.scala
@@ -76,7 +76,7 @@ class HomeController @Inject() (val controllerComponents: ControllerComponents)
         .getOrElse("mismatch")
 
     val ts = Instant.now().toEpochMilli
-    writeFile(s"$ts.json", rawState.toString())
+    writeFile(s"$ts-$stateId.json", rawState.toString())
   }
 
   def writeFile(filename: String, s: String): Unit = {


### PR DESCRIPTION
This adds the state message ID as well, to prevent
collisions when two state files log at the same timestamp