### PR TITLE
feat: win rates segmented by table size

### DIFF
--- a/sinister-service/app/actors/TableRegistry.scala
+++ b/sinister-service/app/actors/TableRegistry.scala
@@ -21,7 +21,8 @@ class TableRegistry extends Actor {
       context become active(newRegistry)
 
     case TableById(tableId) =>
-      sender() ! registry.get(tableId)
+      val matchingTable = registry.get(tableId)
+      sender() ! matchingTable
   }
 }
 

--- a/sinister-service/app/controllers/PlayerController.scala
+++ b/sinister-service/app/controllers/PlayerController.scala
@@ -2,9 +2,7 @@ package controllers
 
 import io.circe.syntax.EncoderOps
 import io.circe.{Json, ParsingFailure, parser, Error => CError}
-import models.gamestate.playeraction.{Bet, Call, Raise}
-import models.gamestate.{AppliesToPlayer, HandEvent}
-import models.opponent.PlayStyle
+import models.opponent.Profile
 import models.{Hand, HandArchive, Participant}
 import play.api.Logger
 import play.api.libs.circe.Circe
@@ -52,92 +50,6 @@ class PlayerController @Inject() (
 
   val logger = Logger("application")
 
-  def voluntarilyPlayedHands(hands: Seq[Hand], player: String): Seq[Hand] = {
-    val voluntarilyPlayed = hands.filter { hand =>
-      val playerPosition = hand.positionForPlayer(player)
-
-      val voluntaryAction = hand.preflopEvents.exists {
-        case c: Call  => c.seatIndex == playerPosition
-        case r: Raise => r.seatIndex == playerPosition
-        case _        => false
-      }
-
-      voluntaryAction
-    }
-
-    voluntarilyPlayed
-  }
-
-  case class BettingEvents(
-      aggressor: Seq[HandEvent],
-      passive: Seq[HandEvent]
-  ) {
-    def +(that: BettingEvents): BettingEvents = {
-      BettingEvents(
-        this.aggressor ++ that.aggressor,
-        this.passive ++ that.passive
-      )
-    }
-  }
-
-  def calculateAggressionFactor(player: String, hands: Seq[Hand]): Double = {
-    val playerWagers = hands
-      .map(hand => {
-        val playerPosition = hand.positionForPlayer(player)
-        val playerEvents = hand.events.filter {
-          case atp: AppliesToPlayer => atp.seatIndex == playerPosition
-          case _                    => false
-        }
-
-        val bettingEvents = playerEvents
-          .filter {
-            case _: Raise => true
-            case _: Bet   => true
-            case _: Call  => true
-            case _        => false
-          }
-          // Using not Call as it's shorter
-          .partition(!_.isInstanceOf[Call])
-
-        bettingEvents
-      })
-      .map(BettingEvents.tupled)
-      .fold(BettingEvents(Nil, Nil))(_ + _)
-
-    val aggressionFactor =
-      ((playerWagers.aggressor.length.toDouble / playerWagers.passive.length) * 10).round / 10d
-
-    aggressionFactor
-  }
-
-  def generatePlayStyle(hands: Seq[Hand], player: String): PlayStyle = {
-    val voluntaryPlayed = voluntarilyPlayedHands(hands, player)
-    val playedCount = hands.length
-
-    val aggressivelyPlayed = voluntaryPlayed.filter(hand => {
-      val playerPosition = hand.positionForPlayer(player)
-      val aggressiveAction = hand.preflopEvents.exists {
-        case r: Raise => r.seatIndex == playerPosition
-        case _        => false
-      }
-
-      aggressiveAction
-    })
-
-    val aggressionFactor = calculateAggressionFactor(player, hands)
-
-    val vpipHands = voluntaryPlayed.length
-    val pfrHands = aggressivelyPlayed.length
-
-    val vpip = ((vpipHands.toDouble / playedCount) * 1000).round / 10f
-    val pfr = ((pfrHands.toDouble / playedCount) * 1000).round / 10f
-
-    val aggressionRatio = ((pfr / vpip) * 1000).round / 100f
-
-    PlayStyle(vpip, pfr, aggressionRatio, aggressionFactor)
-
-  }
-
   def playerStats(player: String): Action[AnyContent] =
     Action { implicit request: Request[AnyContent] =>
       val enumerated = enumeratePastHandsForPlayer(player).map(_.hand)
@@ -147,33 +59,35 @@ class PlayerController @Inject() (
         hand.winners().contains(player)
       }
 
-      val playStyle = generatePlayStyle(enumerated, player)
+      val overallProfile = Profile(enumerated, player)
 
       val recentHands =
-        enumerated.sortBy(_.handId)(Ordering.Int.reverse).take(80)
-      val recentPlayStyle = generatePlayStyle(recentHands, player)
+        enumerated.sortBy(_.handId)(Ordering.Int.reverse).take(100)
+      val recentProfile = Profile(recentHands, player)
 
       val fullTableHands =
         enumerated.filter(_.seatedPlayers.flatten.length >= 7)
-      val fullTableStyle = generatePlayStyle(fullTableHands, player)
+      val fullTableProfile = Profile(fullTableHands, player)
 
       val sixMaxHands =
-        enumerated.filter(hand => hand.seatedPlayers.flatten.length <= 4 && hand.seatedPlayers.flatten.length < 7)
-      val sixMaxStyle = generatePlayStyle(fullTableHands, player)
+        enumerated.filter(hand =>
+          hand.seatedPlayers.flatten.length <= 4 && hand.seatedPlayers.flatten.length < 7
+        )
+      val sixMaxProfile = Profile(sixMaxHands, player)
 
-
-      val shortHanded =
+      val shortHanded = {
         enumerated.filter(_.seatedPlayers.flatten.length <= 3)
-      val shortHandedStyle = generatePlayStyle(shortHanded, player)
+      }
+      val shortHandedProfile = Profile(shortHanded, player)
 
       val outgoing = Json.obj(
         "seen" -> playedCount.asJson,
         "won" -> Json.fromInt(wins.length),
-        "playStyle" -> playStyle.asJson,
-        "recentStyle" -> recentPlayStyle.asJson,
-        "fullTableStyle" -> fullTableStyle.asJson,
-        "sixMaxHand" -> sixMaxStyle.asJson,
-        "shortHandedStyle" -> shortHandedStyle.asJson
+        "overall" -> overallProfile.asJson,
+        "recent" -> recentProfile.asJson,
+        "fullTable" -> fullTableProfile.asJson,
+        "sixMax" -> sixMaxProfile.asJson,
+        "shortHanded" -> shortHandedProfile.asJson
       )
       Ok(outgoing)
     }
@@ -205,7 +119,15 @@ class PlayerController @Inject() (
 
       val handJson = parseResult
         .map(handArchive => {
-          handArchive.hand.asJson
+          val h = handArchive.hand
+          val bbWon = h.bigBlindsWonByPlayer(player)
+          val res = bbWon
+            .flatMap { winnings =>
+              h.asJson.asObject.map { _.add("bbWon", winnings.asJson).asJson }
+            }
+            .getOrElse(h.asJson)
+
+          res
         })
         .getOrElse("".asJson)
 

--- a/sinister-service/app/models/opponent/PlayStyle.scala
+++ b/sinister-service/app/models/opponent/PlayStyle.scala
@@ -15,42 +15,46 @@ case class PlayStyle(
 ) {
 
   def playType(): String = {
-    val frequency = if (vpip <= 14) {
-      PlayStyle.VeryTight
-    } else if (14 < vpip && vpip <= 23) {
-      PlayStyle.Tight
-    } else if (23 < vpip && vpip <= 32) {
-      PlayStyle.SemiLoose
-    } else if (32 < vpip && vpip <= 40) {
-      PlayStyle.Loose
-    } else if (40 < vpip) {
-      PlayStyle.VeryLoose
+    if (vpip + pfr + aggressionFactor +aggressionRatio == 0) {
+      "learning..."
     } else {
-      PlayStyle.Mismatch
+      val frequency = if (vpip <= 14) {
+        PlayStyle.VeryTight
+      } else if (14 < vpip && vpip <= 23) {
+        PlayStyle.Tight
+      } else if (23 < vpip && vpip <= 32) {
+        PlayStyle.SemiLoose
+      } else if (32 < vpip && vpip <= 40) {
+        PlayStyle.Loose
+      } else if (40 < vpip) {
+        PlayStyle.VeryLoose
+      } else {
+        PlayStyle.Mismatch
+      }
+
+      val betStyle = if (aggressionRatio >= 7) {
+        PlayStyle.Aggressive
+      } else {
+        PlayStyle.Passive
+      }
+
+      val category = (frequency, betStyle) match {
+
+        case (VeryTight, Passive) => "rock+"
+        case (VeryTight, Aggressive) => "nit"
+        case (Tight, Passive) => "rock"
+        case (Tight, Aggressive) => "TAG"
+        case (SemiLoose, Passive) => "fish"
+        case (SemiLoose, Aggressive) => "regular"
+        case (Loose, Passive) => "call-station"
+        case (Loose, Aggressive) => "LAG"
+        case (VeryLoose, Passive) => "whale"
+        case (VeryLoose, Aggressive) => "maniac"
+        case _ => "uk"
+      }
+
+      s"$frequency/$betStyle/$category"
     }
-
-    val betStyle = if (aggressionRatio >= 7) {
-      PlayStyle.Aggressive
-    } else {
-      PlayStyle.Passive
-    }
-
-    val category = (frequency, betStyle) match {
-
-      case (VeryTight, Passive)    => "rock+"
-      case (VeryTight, Aggressive) => "nit"
-      case (Tight, Passive)        => "rock"
-      case (Tight, Aggressive)     => "TAG"
-      case (SemiLoose, Passive)    => "fish"
-      case (SemiLoose, Aggressive) => "regular"
-      case (Loose, Passive)        => "call-station"
-      case (Loose, Aggressive)     => "LAG"
-      case (VeryLoose, Passive)    => "whale"
-      case (VeryLoose, Aggressive) => "maniac"
-      case _                       => "uk"
-    }
-
-    s"$frequency/$betStyle/$category"
   }
 }
 

--- a/sinister-service/app/models/opponent/Profile.scala
+++ b/sinister-service/app/models/opponent/Profile.scala
@@ -1,0 +1,120 @@
+package models.opponent
+
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
+import models.Hand
+import models.gamestate.{AppliesToPlayer, HandEvent}
+import models.gamestate.playeraction.{Bet, Call, Raise}
+
+import scala.math.BigDecimal.RoundingMode
+
+case class Profile(playStyle: PlayStyle, winRate: BigDecimal) {}
+
+object Profile {
+  private val UnknownProfile = Profile(PlayStyle(0,0,0,0), 0)
+  implicit val encoder: Encoder[Profile] = deriveEncoder
+
+  def apply(hands: Seq[Hand], player: String): Profile = {
+    if (hands.nonEmpty) {
+      val playStyle = generatePlayStyle(hands, player)
+      val winRate = bbPer100(hands, player)
+
+      Profile(playStyle, winRate)
+    } else { UnknownProfile }
+  }
+
+  def bbPer100(hands: Seq[Hand], player: String): BigDecimal = {
+    val handCount = hands.length
+
+    if (handCount > 0) {
+      (hands.flatMap(_.bigBlindsWonByPlayer(player)).sum / handCount * 100)
+        .setScale(2, RoundingMode.DOWN)
+        .rounded
+    } else { 0 }
+  }
+
+  def generatePlayStyle(hands: Seq[Hand], player: String): PlayStyle = {
+    val voluntaryPlayed = voluntarilyPlayedHands(hands, player)
+    val playedCount = hands.length
+
+    val aggressivelyPlayed = voluntaryPlayed.filter(hand => {
+      val playerPosition = hand.positionForPlayer(player)
+      val aggressiveAction = hand.preflopEvents.exists {
+        case r: Raise => r.seatIndex == playerPosition
+        case _        => false
+      }
+
+      aggressiveAction
+    })
+
+    val aggressionFactor = calculateAggressionFactor(player, hands)
+
+    val vpipHands = voluntaryPlayed.length
+    val pfrHands = aggressivelyPlayed.length
+
+    val vpip = ((vpipHands.toDouble / playedCount) * 1000).round / 10f
+    val pfr = ((pfrHands.toDouble / playedCount) * 1000).round / 10f
+
+    val aggressionRatio = ((pfr / vpip) * 1000).round / 100f
+
+    PlayStyle(vpip, pfr, aggressionRatio, aggressionFactor)
+  }
+
+  case class BettingEvents(
+      aggressor: Seq[HandEvent],
+      passive: Seq[HandEvent]
+  ) {
+    def +(that: BettingEvents): BettingEvents = {
+      BettingEvents(
+        this.aggressor ++ that.aggressor,
+        this.passive ++ that.passive
+      )
+    }
+  }
+
+  def calculateAggressionFactor(player: String, hands: Seq[Hand]): Double = {
+    val playerWagers = hands
+      .map(hand => {
+        val playerPosition = hand.positionForPlayer(player)
+        val playerEvents = hand.events.filter {
+          case atp: AppliesToPlayer => atp.seatIndex == playerPosition
+          case _                    => false
+        }
+
+        val bettingEvents = playerEvents
+          .filter {
+            case _: Raise => true
+            case _: Bet   => true
+            case _: Call  => true
+            case _        => false
+          }
+          // Using not Call as it's shorter
+          .partition(!_.isInstanceOf[Call])
+
+        bettingEvents
+      })
+      .map(BettingEvents.tupled)
+      .fold(BettingEvents(Nil, Nil))(_ + _)
+
+    val aggressionFactor =
+      ((playerWagers.aggressor.length.toDouble / playerWagers.passive.length) * 10).round / 10d
+
+    aggressionFactor
+  }
+
+  def voluntarilyPlayedHands(hands: Seq[Hand], player: String): Seq[Hand] = {
+    val voluntarilyPlayed = hands.filter { hand =>
+      val playerPosition = hand.positionForPlayer(player)
+
+      val voluntaryAction = hand.preflopEvents.exists {
+        case c: Call  => c.seatIndex == playerPosition
+        case r: Raise => r.seatIndex == playerPosition
+        case _        => false
+      }
+
+      voluntaryAction
+    }
+
+    voluntarilyPlayed
+  }
+}


### PR DESCRIPTION
This calculates the win rate (BB per 100 hands)
grouped by:

  * 9max (7-9)
  * 6max (4-6)
  * shortHanded (2-3)

While cleaning up some of the player stat logic.